### PR TITLE
Fix lkup to work for items before the end of the list.

### DIFF
--- a/encodings-text.md
+++ b/encodings-text.md
@@ -299,7 +299,7 @@ data Var = VZero | VSucc Var deriving Show
 
 -- We need a way to look up variables in our environment.
 lkup :: Var -> [x] -> x
-lkup VZero [x] = x
+lkup VZero (x:_) = x
 lkup (VSucc v) (_:moar) = lkup v moar
 lkup _ _ = error "sorry, dawg; I can't interpret an open term!"
 ~~~~

--- a/encodings.md
+++ b/encodings.md
@@ -246,7 +246,7 @@ data Var = VZero | VSucc Var deriving Show
 
 -- We need a way to look up variables in our environment.
 lkup :: Var -> [x] -> x
-lkup VZero [x] = x
+lkup VZero (x:_) = x
 lkup (VSucc v) (_:moar) = lkup v moar
 lkup _ _ = error "sorry, dawg; I can't interpret an open term!"
 ~~~~


### PR DESCRIPTION
Under the original behavior, each of these triggers the error case:
  lkup VZero [0,1,2]                                    -- incorrect: should be 0
  lkup (VSucc VZero) [0,1,2]                            -- incorrect: should be 1
  lkup (VSucc $ VSucc $ VSucc VZero) [0,1,2]            -- correct
And this triggers an error for any value (v :: Var):
  lkup v [0..]                                          -- incorrect: should be 'v' as an int

With this change, all work correctly.
